### PR TITLE
fix for the overlay always display

### DIFF
--- a/abc-output.php
+++ b/abc-output.php
@@ -45,8 +45,17 @@ class ABC_Output extends ABC_Core
                     return $this->build_html( $show_browsers, $old_ie, $user_browser );
                 }
             }
+            return $this->build_success();
         }
     }
+    
+    /**
+     * Return the response for a valid browser
+     * @return string
+     */
+     private function build_success(){
+       	return "success";
+     }
 
     /**
      * Build the HTML for the popup

--- a/js/script.js
+++ b/js/script.js
@@ -13,7 +13,10 @@ jQuery(document).ready(function($){
 			$.post(url.abc_url, ajax_action, function(response) {
 				
 				if(response) {
-
+					// If the browser is valid
+					if(response=="success"){
+						$('.advanced-browser-check').hide();
+					}
 					// We will need to add a css class to the body
 					// if we detect IE 6 for combability css to load
 					// properly


### PR DESCRIPTION
This fix is related to this issue
[ https://wordpress.org/support/topic/advanced-browser-check-overlay-always-display/](url)

The div containing the pop up has no style display:none, the problem was the ajax callback did not return response. The response is set if it's a valid browser now.